### PR TITLE
OEL-2765: Update drone matrix to support last two 10.x minors.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,12 +31,9 @@ services:
       - SPARQL_UPDATE=true
       - DBA_PASSWORD=dba
   selenium:
-    image: registry.fpfis.eu/fpfis/selenium:standalone-chrome-3.141.59-oxygen
-    pull: true
-    shm_size: 2g
+    image: registry.fpfis.eu/fpfis/selenium:standalone-chrome-4.1.3-20220405
     environment:
       - DISPLAY=:99
-      - SE_OPTS=-debug
       - SCREEN_WIDTH=1280
       - SCREEN_HEIGHT=800
       - NODE_MAX_INSTANCES=5
@@ -79,7 +76,11 @@ pipeline:
 
 matrix:
   include:
-    - CORE_VERSION: 9.5
-      PHP_VERSION: 8.1
     - CORE_VERSION: 10.0
       PHP_VERSION: 8.1
+    - CORE_VERSION: 10.0
+      PHP_VERSION: 8.2
+    - CORE_VERSION: 10.1
+      PHP_VERSION: 8.1
+    - CORE_VERSION: 10.1
+      PHP_VERSION: 8.2


### PR DESCRIPTION
Drupal 9.x is unsupported now.