### PR TITLE
OEL-2903: [*_anonymous] Handle conflict with email already used.

### DIFF
--- a/modules/oe_subscriptions_anonymous/config/mailer_override/symfony_mailer.mailer_policy.oe_subscriptions_anonymous.email_taken.yml
+++ b/modules/oe_subscriptions_anonymous/config/mailer_override/symfony_mailer.mailer_policy.oe_subscriptions_anonymous.email_taken.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - oe_subscriptions_anonymous
+id: oe_subscriptions_anonymous.email_taken
+configuration:
+  email_subject:
+    value: 'Cannot subscribe to {{ entity_label }}'
+  email_body:
+    content:
+      value: |-
+        <p>Thank you for showing interest in keeping up with the updates for <a href="{{ entity_url }}">{{ entity_label }}</a>!</p>
+        <p>The email address you were using to subscribe is already associated with a regular account on this website.</p>
+        <p>If you still want to subscribe to content updates for this item, you should log into the website, using your existing account, and then subscribe as a regular user.</p>
+        <p>If you do not want to subscribe, you can ignore this message.</p>
+      format: email_html

--- a/modules/oe_subscriptions_anonymous/src/AnonymousSubscriptionManager.php
+++ b/modules/oe_subscriptions_anonymous/src/AnonymousSubscriptionManager.php
@@ -22,7 +22,10 @@ class AnonymousSubscriptionManager implements AnonymousSubscriptionManagerInterf
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
    */
-  public function __construct(protected FlagServiceInterface $flagService, protected EntityTypeManagerInterface $entityTypeManager) {}
+  public function __construct(
+    protected readonly FlagServiceInterface $flagService,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
 
   /**
    * {@inheritdoc}

--- a/modules/oe_subscriptions_anonymous/src/Controller/SubscriptionAnonymousController.php
+++ b/modules/oe_subscriptions_anonymous/src/Controller/SubscriptionAnonymousController.php
@@ -96,9 +96,10 @@ class SubscriptionAnonymousController extends ControllerBase {
       return $response;
     }
 
-    $this->subscriptionManager->subscribe($email, $flag, $entity_id);
     // The token has been used, so we need to invalidate it.
     $this->tokenManager->delete($email, $scope);
+
+    $this->subscriptionManager->subscribe($email, $flag, $entity_id);
     // Success message and redirection to entity.
     $this->messenger()->addMessage($this->t('Your subscription request has been confirmed.'));
 

--- a/modules/oe_subscriptions_anonymous/src/Form/AnonymousSubscribeForm.php
+++ b/modules/oe_subscriptions_anonymous/src/Form/AnonymousSubscribeForm.php
@@ -154,6 +154,10 @@ class AnonymousSubscribeForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $mail = $form_state->getValue('email');
+    /**
+     * @var \Drupal\flag\FlagInterface $flag
+     * @var string|int $entity_id
+     */
     [$flag, $entity_id] = $form_state->getBuildInfo()['args'];
 
     // @todo Send a different e-mail when the user is already subscribed.

--- a/modules/oe_subscriptions_anonymous/src/Form/AnonymousSubscribeForm.php
+++ b/modules/oe_subscriptions_anonymous/src/Form/AnonymousSubscribeForm.php
@@ -160,18 +160,22 @@ class AnonymousSubscribeForm extends FormBase {
      */
     [$flag, $entity_id] = $form_state->getBuildInfo()['args'];
 
+    $mail_key = 'subscription_create';
+    $mail_params = [
+      'email' => $mail,
+      'flag' => $flag,
+      'entity_id' => $entity_id,
+    ];
+
     // @todo Send a different e-mail when the user is already subscribed.
     // @todo Send a different e-mail if the user is coupled.
     $result = $this->mailManager->mail(
       'oe_subscriptions_anonymous',
-      'subscription_create',
+      $mail_key,
       $mail,
       $this->languageManager->getCurrentLanguage()->getId(),
-      [
-        'email' => $mail,
-        'flag' => $flag,
-        'entity_id' => $entity_id,
-      ]);
+      $mail_params,
+    );
 
     if (!$result) {
       $this->messenger()->addError($this->t('An error occurred when sending the confirmation e-mail. Please contact the administrator.'));

--- a/modules/oe_subscriptions_anonymous/src/MailTemplate/EmailTaken.php
+++ b/modules/oe_subscriptions_anonymous/src/MailTemplate/EmailTaken.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\oe_subscriptions_anonymous\MailTemplate;
+
+use Drupal\Core\DependencyInjection\AutowireTrait;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+
+/**
+ * Prepares the "email_taken" mail.
+ */
+class EmailTaken implements ContainerInjectionInterface, MailTemplateInterface {
+
+  use StringTranslationTrait;
+  use AutowireTrait;
+
+  /**
+   * Creates a new instance of this class.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   Entity type manager.
+   */
+  public function __construct(
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getParameters(): array {
+    return [
+      'email',
+      'entity_type',
+      'entity_id',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getVariables(array $params): array {
+    [
+      'entity_type' => $entity_type,
+      'entity_id' => $entity_id,
+    ] = $params;
+
+    $entity = $this->entityTypeManager
+      ->getStorage($entity_type)
+      ->load($entity_id);
+
+    // @todo In theory, it is possible that the entity no longer exists.
+    return [
+      'entity_label' => $entity->label(),
+      'entity_url' => $entity->toUrl()->setAbsolute()->toString(),
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function prepare(array $params): array {
+    $variables = $this->getVariables($params);
+
+    $message['subject'] = $this->t('Cannot subscribe to @entity_label', [
+      '@entity_label' => $variables['entity_label'],
+    ]);
+
+    $message['body'] = $this->t(
+      '<p>Thank you for showing interest in keeping up with the updates for <a href=":entity_url">@entity_label</a>!</p>
+<p>The email address you were using to subscribe is already associated with a regular account on this website.</p>
+<p>If you still want to subscribe to content updates for this item, you should log into the website, using your existing account, and then subscribe as a regular user.</p>
+<p>If you do not want to subscribe, you can ignore this message.</p>',
+      [
+        '@entity_label' => $variables['entity_label'],
+        ':entity_url' => $variables['entity_url'],
+      ],
+    );
+
+    return $message;
+  }
+
+}

--- a/modules/oe_subscriptions_anonymous/src/MailTemplate/MailTemplateHelper.php
+++ b/modules/oe_subscriptions_anonymous/src/MailTemplate/MailTemplateHelper.php
@@ -17,6 +17,7 @@ final class MailTemplateHelper {
   public static function getMailTemplate(string $key): MailTemplateInterface {
     return \Drupal::classResolver(match ($key) {
       'subscription_create' => SubscriptionCreate::class,
+      'email_taken' => EmailTaken::class,
       'user_subscriptions_access' => UserSubscriptionsAccess::class,
     });
   }

--- a/modules/oe_subscriptions_anonymous/src/MailTemplate/MailTemplateInterface.php
+++ b/modules/oe_subscriptions_anonymous/src/MailTemplate/MailTemplateInterface.php
@@ -29,7 +29,9 @@ interface MailTemplateInterface {
   public function getVariables(array $params): array;
 
   /**
-   * Prepares the mail template.
+   * Prepares the mail content if the core mailer is used.
+   *
+   * This method has no effect if the emails are sent with symfony_mailer.
    *
    * @param array $params
    *   Mail parameters.

--- a/modules/oe_subscriptions_anonymous/src/Plugin/EmailBuilder/AnonymousEmailBuilder.php
+++ b/modules/oe_subscriptions_anonymous/src/Plugin/EmailBuilder/AnonymousEmailBuilder.php
@@ -19,6 +19,7 @@ use Drupal\symfony_mailer\Processor\TokenProcessorTrait;
  *   label = @Translation("Anonymous subscriptions"),
  *   sub_types = {
  *     "subscription_create" = @Translation("Subscription confirmation creation"),
+ *     "email_taken" = @Translation("Subscription confirmation - email address already taken"),
  *     "user_subscriptions_access" = @Translation("Subscriptions page access request"),
  *   },
  *   override = TRUE,

--- a/modules/oe_subscriptions_anonymous/src/Plugin/EmailBuilder/AnonymousEmailBuilder.php
+++ b/modules/oe_subscriptions_anonymous/src/Plugin/EmailBuilder/AnonymousEmailBuilder.php
@@ -67,7 +67,6 @@ class AnonymousEmailBuilder extends EmailBuilderBase {
     $email->setVariables($mail_template->getVariables($params));
 
     $email->setTo(new Address($params['email']));
-
   }
 
 }

--- a/modules/oe_subscriptions_anonymous/tests/src/Functional/HtmlMailsTest.php
+++ b/modules/oe_subscriptions_anonymous/tests/src/Functional/HtmlMailsTest.php
@@ -104,14 +104,7 @@ BODY);
     $this->drupalLogout();
 
     // Visit the article, and submit a subscribe request.
-    $article_url = $this->article->toUrl()->setAbsolute()->toString();
-    $this->drupalGet($article_url);
-    $this->clickLink('Subscribe');
-    $this->submitForm([
-      'Your e-mail' => 'anothertest@test.com',
-      'I have read and agree with the data protection terms.' => '1',
-    ], 'Subscribe me');
-    $this->assertSubscriptionCreateMailStatusMessage();
+    $this->requestSubscriptionForArticle('anothertest@test.com');
 
     // Receive the subscribe confirm email.
     // The email content now follows the overridden template.
@@ -124,6 +117,7 @@ BODY);
     $this->assertCount(4, $spans);
     $this->assertEquals(['span'], array_unique(array_map(static fn ($tag) => $tag->nodeName, iterator_to_array($spans->getIterator()))));
     $this->assertEquals($this->article->label(), $spans->eq(0)->html());
+    $article_url = $this->article->toUrl()->setAbsolute()->toString();
     $this->assertEquals($article_url, $spans->eq(1)->html());
 
     // Visit the confirm url from the email.
@@ -135,13 +129,7 @@ BODY);
 
     // Visit the article, and submit a subscribe request, again.
     // This is needed to get a fresh cancel url.
-    $this->drupalGet($article_url);
-    $this->clickLink('Subscribe');
-    $this->submitForm([
-      'Your e-mail' => 'secondtest@test.com',
-      'I have read and agree with the data protection terms.' => '1',
-    ], 'Subscribe me');
-    $this->assertSubscriptionCreateMailStatusMessage();
+    $this->requestSubscriptionForArticle('secondtest@test.com');
 
     // Receive the confirm email.
     $mail = $this->readMail();
@@ -197,16 +185,9 @@ BODY);
    */
   protected function doTestDefaultHtmlEmailContents(): void {
     $article_label = $this->article->label();
-    $article_url = $this->article->toUrl()->setAbsolute()->toString();
 
     // Visit the article, and submit a subscribe request.
-    $this->drupalGet($article_url);
-    $this->clickLink('Subscribe');
-    $this->submitForm([
-      'Your e-mail' => 'test@test.com',
-      'I have read and agree with the data protection terms.' => '1',
-    ], 'Subscribe me');
-    $this->assertSubscriptionCreateMailStatusMessage();
+    $this->requestSubscriptionForArticle('test@test.com');
 
     // Receive the confirm email, and visit the confirm link.
     $mail = $this->readMail();
@@ -217,13 +198,7 @@ BODY);
 
     // Visit the article, and submit a subscribe request, again.
     // This is needed to get a fresh cancel url.
-    $this->drupalGet($article_url);
-    $this->clickLink('Subscribe');
-    $this->submitForm([
-      'Your e-mail' => 'test@test.com',
-      'I have read and agree with the data protection terms.' => '1',
-    ], 'Subscribe me');
-    $this->assertSubscriptionCreateMailStatusMessage();
+    $this->requestSubscriptionForArticle('test@test.com');
 
     // Receive the confirm email, and visit the cancel link.
     $mail = $this->readMail();
@@ -250,6 +225,25 @@ BODY);
     $assert_session = $this->assertSession();
     $assert_session->titleEquals('Manage your subscriptions | Drupal');
     $assert_session->elementExists('css', 'table.user-subscriptions');
+  }
+
+  /**
+   * Requests a subscription to the article.
+   *
+   * @param string $email
+   *   The email address to use in the subscribe form.
+   */
+  protected function requestSubscriptionForArticle(string $email): void {
+    $article_url = $this->article->toUrl()->setAbsolute()->toString();
+
+    // Visit the article, and submit a subscribe request.
+    $this->drupalGet($article_url);
+    $this->clickLink('Subscribe');
+    $this->submitForm([
+      'Your e-mail' => $email,
+      'I have read and agree with the data protection terms.' => '1',
+    ], 'Subscribe me');
+    $this->assertSubscriptionCreateMailStatusMessage();
   }
 
   /**

--- a/modules/oe_subscriptions_anonymous/tests/src/Functional/HtmlMailsTest.php
+++ b/modules/oe_subscriptions_anonymous/tests/src/Functional/HtmlMailsTest.php
@@ -333,13 +333,15 @@ BODY);
   /**
    * Asserts links returning those without URL key value.
    *
-   * @param array[] $expected_links
-   *   A list links to check.
+   * @param list<array{text: string, url?: string}> $expected_links
+   *   Expected link texts and urls.
+   *   If no expected url is provided for a link, the actual url will be in the
+   *   return value.
    * @param \Symfony\Component\DomCrawler\Crawler $crawler
    *   The crawler where perform the checks.
    *
-   * @return array
-   *   The text only urls.
+   * @return list<string>
+   *   Urls for the links where no expected url was provided.
    */
   protected function assertLinks(array $expected_links, Crawler $crawler): array {
     $text_only_urls = [];

--- a/modules/oe_subscriptions_anonymous/tests/src/Functional/SubscribeTest.php
+++ b/modules/oe_subscriptions_anonymous/tests/src/Functional/SubscribeTest.php
@@ -6,6 +6,7 @@ namespace Drupal\Tests\oe_subscriptions_anonymous\Functional;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Url;
+use Drupal\decoupled_auth\DecoupledAuthUserInterface;
 use Drupal\flag\FlagInterface;
 use Drupal\oe_subscriptions_anonymous\SettingsFormAlter;
 use Drupal\Tests\BrowserTestBase;
@@ -132,6 +133,9 @@ class SubscribeTest extends BrowserTestBase {
     $account = user_load_by_mail('test@test.com');
     $this->assertNotEmpty($account);
     $this->assertTrue($article_flag->isFlagged($article, $account));
+    // The account is not a full account, but a "decoupled" account.
+    $this->assertInstanceOf(DecoupledAuthUserInterface::class, $account);
+    $this->assertFalse($account->isCoupled());
 
     // The cancel link from the confirm email is now invalid.
     $this->drupalGet($mail_urls[3]);

--- a/modules/oe_subscriptions_anonymous/tests/src/Functional/SubscribeTest.php
+++ b/modules/oe_subscriptions_anonymous/tests/src/Functional/SubscribeTest.php
@@ -257,6 +257,43 @@ class SubscribeTest extends BrowserTestBase {
   }
 
   /**
+   * Tests a case where an email is taken when a reqest is confirmed.
+   */
+  public function testEmailTakenOnConfirm(): void {
+    // Create flag and page.
+    $pages_flag = $this->createFlagFromArray([
+      'id' => 'subscribe_page',
+      'entity_type' => 'node',
+      'bundles' => ['page'],
+    ]);
+    $page = $this->drupalCreateNode([
+      'type' => 'page',
+      'status' => 1,
+    ]);
+
+    // Request to subscribe as anonymous, at a time when no account exists yet
+    // with this email address.
+    $this->requestSubscriptionForEntity($pages_flag, $page, 'conflict@example.com');
+
+    // Receive the confirm email.
+    $mails = $this->getMails();
+    $this->assertCount(1, $mails);
+    $mail_urls = $this->assertSubscriptionConfirmationMail($mails[0], 'conflict@example.com', $pages_flag, $page);
+
+    // Create a regular user account with the same email address.
+    // Do this before visiting the confirm link.
+    $this->createUser(values: ['mail' => 'conflict@example.com']);
+
+    // Visit the confirm link from the email.
+    $this->drupalGet($mail_urls[2]);
+
+    $assert_session = $this->assertSession();
+    $assert_session->statusMessageContains('You have attempted to subscribe as anonymous, using an email address that is already associated with a regular account.', 'warning');
+    $assert_session->statusMessageContains('If you still want to subscribe, you should log in and subscribe as a regular user.', 'warning');
+    $assert_session->addressEquals($page->toUrl()->setAbsolute()->toString());
+  }
+
+  /**
    * Tests the terms and conditions link.
    */
   public function testTermsAndConditionsLink() {


### PR DESCRIPTION
https://citnet.tech.ec.europa.eu/CITnet/jira/browse/OEL-2903

For `oe_subscriptions_anonymous`.

### Background
If you subscribe as anonymous for the first time, we create a "decoupled" account with that email address.
If the email address is already taken, for a regular user account, this won't work.

### Problem
Currently this kind of conflict results in an error page.

### Proposed change
- When a subscription is requested, and we detect the email conflict, we send an alternative email, asking to subscribe as registered user.
- When a user visits a confirm link, and we detect the email conflict, we show a meaningful message instead of an error page. (This case only occurs if the user creates an account before they click the confirm link).

### Unrelated changes
The PR also contains some minor refactoring, TBD.

### Remaining tasks
We also want to send a different email if the user is already subscribed.
But for now we don't have a text for it.